### PR TITLE
feature/allowed-values-validator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 * fix: Console colour for success messages [pr](https://github.com/barry-jones/csv-validator/pull/17), closes [#16](https://github.com/barry-jones/csv-validator/issues/9)
 * feat: Added non-zero exit code for validation failures [pr31](https://github.com/barry-jones/csv-validator/pull/31).
 * feat: Added structured output to JSON or CSV with flags [pr32](https://github.com/barry-jones/csv-validator/pull/32).
+* feat: allowedValues validator lets users limit values to a specific set [pr33](https://github.com/barry-jones/csv-validator/pull/33).
 
 ## [v1.0.4](https://github.com/barry-jones/csv-validator/releases/tag/v1.0.4)
 

--- a/README.md
+++ b/README.md
@@ -69,6 +69,10 @@ The expected width is taken from the column schema: it is the **highest configur
     // Maximum allowable length for a column
     "maxLength": "int",
     // Check if content is numerical
+    "isNumeric": true|false,
+    // Check if content is in a specific set
+    "allowedValues": ["value1", "value2", ...]
+    // Check if content is numerical
     "isNumeric": true|false
 }
 ```

--- a/src/Validate.Lib/ColumnValidatorConfiguration.cs
+++ b/src/Validate.Lib/ColumnValidatorConfiguration.cs
@@ -1,6 +1,8 @@
 ﻿
 namespace FormatValidator
 {
+    using System.Collections.Generic;
+
     public class ColumnValidatorConfiguration
     {
         public string Name { get; set; }
@@ -13,6 +15,11 @@ namespace FormatValidator
 
         public bool IsNumeric { get; set; }
 
-        public bool IsRequired { get; set; }        
+        public bool IsRequired { get; set; }
+
+        /// <summary>
+        /// The set of permitted values for this column. When non-empty, any cell value not in this list is a validation error.
+        /// </summary>
+        public List<string> AllowedValues { get; set; }
     }
 }

--- a/src/Validate.Lib/ConfigurationConvertor.cs
+++ b/src/Validate.Lib/ConfigurationConvertor.cs
@@ -49,6 +49,7 @@ namespace FormatValidator
                     if (!string.IsNullOrWhiteSpace(columnConfig.Value.Pattern)) group.Add(new TextFormatValidator(columnConfig.Value.Pattern));
                     if (columnConfig.Value.IsNumeric) group.Add(new NumberValidator());
                     if (columnConfig.Value.IsRequired) group.Add(new NotNullableValidator());
+                    if (columnConfig.Value.AllowedValues != null && columnConfig.Value.AllowedValues.Count > 0) group.Add(new AllowedValuesValidator(columnConfig.Value.AllowedValues));
 
                     _converted.Columns.Add(columnConfig.Key, group);
                 }

--- a/src/Validate.Lib/Validators/AllowedValuesValidator.cs
+++ b/src/Validate.Lib/Validators/AllowedValuesValidator.cs
@@ -1,0 +1,32 @@
+
+namespace FormatValidator.Validators
+{
+    using System.Collections.Generic;
+
+    internal class AllowedValuesValidator : ValidationEntry
+    {
+        private List<string> _allowedValues;
+
+        public AllowedValuesValidator(IReadOnlyList<string> allowedValues)
+        {
+            _allowedValues = new List<string>(allowedValues);
+        }
+
+        public override bool IsValid(string toCheck)
+        {
+            if (string.IsNullOrEmpty(toCheck))
+                return true;
+
+            bool isValid = _allowedValues.Contains(toCheck);
+            if (!isValid)
+            {
+                base.Errors.Add(new ValidationError(0, string.Format(
+                    "Value '{0}' is not in the list of allowed values [{1}].",
+                    toCheck,
+                    string.Join(", ", _allowedValues))));
+            }
+
+            return isValid;
+        }
+    }
+}

--- a/test/ValidateTests/Unit/AllowedValuesValidatorTests.cs
+++ b/test/ValidateTests/Unit/AllowedValuesValidatorTests.cs
@@ -1,0 +1,84 @@
+
+namespace FormatValidatorTests.Unit
+{
+    using System.Collections.Generic;
+    using FormatValidator.Validators;
+    using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+    [TestClass]
+    public class AllowedValuesValidatorTests
+    {
+        private static readonly IReadOnlyList<string> AllowedList = new List<string> { "YES", "NO", "MAYBE" };
+
+        [TestMethod]
+        public void AllowedValuesValidator_WhenValueIsInAllowedList_IsValid()
+        {
+            AllowedValuesValidator validator = new AllowedValuesValidator(AllowedList);
+
+            bool result = validator.IsValid("YES");
+
+            Assert.IsTrue(result);
+        }
+
+        [TestMethod]
+        public void AllowedValuesValidator_WhenValueIsNotInAllowedList_IsNotValid()
+        {
+            AllowedValuesValidator validator = new AllowedValuesValidator(AllowedList);
+
+            bool result = validator.IsValid("PERHAPS");
+
+            Assert.IsFalse(result);
+        }
+
+        [TestMethod]
+        public void AllowedValuesValidator_WhenValueIsNotInAllowedList_ProducesCorrectErrorMessage()
+        {
+            const string EXPECTED_MESSAGE = "Value 'PERHAPS' is not in the list of allowed values [YES, NO, MAYBE].";
+            AllowedValuesValidator validator = new AllowedValuesValidator(AllowedList);
+
+            validator.IsValid("PERHAPS");
+
+            Assert.AreEqual(EXPECTED_MESSAGE, validator.GetErrors()[0].Message);
+        }
+
+        [TestMethod]
+        public void AllowedValuesValidator_WhenValueIsEmpty_IsValid()
+        {
+            AllowedValuesValidator validator = new AllowedValuesValidator(AllowedList);
+
+            bool result = validator.IsValid(string.Empty);
+
+            Assert.IsTrue(result);
+        }
+
+        [TestMethod]
+        public void AllowedValuesValidator_WhenValueIsNull_IsValid()
+        {
+            AllowedValuesValidator validator = new AllowedValuesValidator(AllowedList);
+
+            bool result = validator.IsValid(null);
+
+            Assert.IsTrue(result);
+        }
+
+        [TestMethod]
+        public void AllowedValuesValidator_WhenValueMatchesExactCase_IsValid()
+        {
+            AllowedValuesValidator validator = new AllowedValuesValidator(AllowedList);
+
+            bool result = validator.IsValid("NO");
+
+            Assert.IsTrue(result);
+        }
+
+        [TestMethod]
+        public void AllowedValuesValidator_WhenValueDiffersByCase_IsNotValid()
+        {
+            AllowedValuesValidator validator = new AllowedValuesValidator(AllowedList);
+
+            bool result = validator.IsValid("yes");
+
+            Assert.IsFalse(result);
+        }
+    }
+}

--- a/test/ValidateTests/Unit/ConfigurationConverterTests.cs
+++ b/test/ValidateTests/Unit/ConfigurationConverterTests.cs
@@ -1,6 +1,7 @@
 ﻿
 namespace FormatValidatorTests.Unit
 {
+    using System.Collections.Generic;
     using System.Linq;
     using FormatValidator;
     using FormatValidator.Validators;
@@ -167,6 +168,16 @@ namespace FormatValidatorTests.Unit
             ConvertedValidators converted = _converter.Convert();
 
             Assert.AreEqual(true, converted.StrictColumns);
+        }
+
+        [TestMethod]
+        public void Converter_WhenColumnHasAllowedValuesAttribute_ShouldCreateValidator()
+        {
+            _configuration.Columns.Add(1, new ColumnValidatorConfiguration() { AllowedValues = new List<string> { "YES", "NO", "MAYBE" } });
+
+            ConvertedValidators validators = _converter.Convert();
+
+            Assert.IsNotNull(validators.Columns[1][0] as AllowedValuesValidator);
         }
     }
 }

--- a/test/ValidateTests/Unit/JsonReaderTests.cs
+++ b/test/ValidateTests/Unit/JsonReaderTests.cs
@@ -83,5 +83,16 @@ namespace FormatValidatorTests.Unit
 
             Assert.AreEqual("\r\n", configuration.RowSeperator);
         }
+
+        [TestMethod]
+        public void JsonReader_WhenAllowedValuesProvided_ShouldBePopulated()
+        {
+            const string INPUT = "{ \"columns\": { \"1\": { \"allowedValues\": [\"YES\", \"NO\", \"MAYBE\"] } } }";
+            JsonReader reader = new JsonReader();
+
+            ValidatorConfiguration configuration = reader.Read(INPUT);
+
+            CollectionAssert.AreEqual(new[] { "YES", "NO", "MAYBE" }, configuration.Columns[1].AllowedValues);
+        }
     }
 }


### PR DESCRIPTION
Implements an allowedValues JSON config option that rejects any cell value not in the specified list. Empty/null cells skip the check (consistent with TextFormatValidator). Match is case-sensitive. New AllowedValuesValidator class is internal; wired through ColumnValidatorConfiguration and ConfigurationConvertor alongside existing MaxLength/Pattern/IsNumeric guards.